### PR TITLE
improved expansion time complexity

### DIFF
--- a/edge.go
+++ b/edge.go
@@ -16,14 +16,3 @@ type Edge struct {
 	/* CostSeconds  float64 */ //@todo: consider cost customization
 	Geom                       []GeoPoint
 }
-
-// findOutComingEdges returns IDs of edges for given OSM Way object
-func findOutComingEdges(givenEdge Edge, edges []Edge) []EdgeID {
-	result := []EdgeID{}
-	for _, edge := range edges {
-		if edge.SourceNodeID == givenEdge.TargetNodeID && edge.ID != givenEdge.ID {
-			result = append(result, edge.ID)
-		}
-	}
-	return result
-}


### PR DESCRIPTION
Why: Current edge expansion technique is very slow on large graphs
Fix: Rather than iterating all edges for each edge, create an edge index before doing the main algorithm

On Oberbayern, a region around Munich, Germany, i was able to go from 21min to 800ms 😄 